### PR TITLE
added camera via xyz,hpr commands in sim initialization

### DIFF
--- a/Demo_18_Camera.py
+++ b/Demo_18_Camera.py
@@ -1,0 +1,30 @@
+from pyrosim import PYROSIM
+#ccappelle
+#Same as Demo 17 except now you can move the initial camera
+
+#xyz - x,y,z coordinate position of the camera
+#hpr - head,pitch, and roll of the camera
+xyz = (0.,-2., 2.0)
+hpr = (90., -25., 0.0)
+
+ARM_LENGTH = 0.5
+
+ARM_RADIUS = ARM_LENGTH / 10.0
+
+#set xyz,hpr in sim initialization
+#defaults to start position being used before xyz=(0.8317,-0.9817,0.8),hpr= (121.0,-27.500,0.0)
+#hints: always set r to 0. it is very disorienting if not 0,
+#		h = 0 => facing along x-axis
+#		h = 90=> facing along y-axis
+sim = PYROSIM(playPaused = False , evalTime = 100, xyz=xyz,hpr=hpr)
+
+sim.Send_Cylinder(objectID = 0 , x=0, y=0, z=ARM_LENGTH/2.0 + 2*ARM_RADIUS, r1=0, r2=0, r3=1, length=ARM_LENGTH, radius=ARM_RADIUS)
+
+sim.Send_Cylinder(objectID = 1 , x=0, y=ARM_LENGTH/2.0, z=ARM_LENGTH + 2*ARM_RADIUS , r1=0, r2=1, r3=0, length=ARM_LENGTH, radius=ARM_RADIUS)
+
+sim.Send_Joint(jointID = 0, firstObjectID=0, secondObjectID=1, x=0, y=0, z=ARM_LENGTH + 2*ARM_RADIUS , n1=1, n2=0, n3=0, lo=-3.14159/4.0, hi=+3.14159/4.0)
+
+sim.Send_Joint(jointID = 1 , firstObjectID=0, secondObjectID=-1, x=0, y=0, z=ARM_LENGTH/2.0 + 2*ARM_RADIUS)
+
+sim.Start()
+

--- a/pyrosim.py
+++ b/pyrosim.py
@@ -8,7 +8,8 @@ from subprocess import Popen, PIPE
 
 class PYROSIM:
 
-	def __init__(self,playBlind=False,playPaused=False,evalTime=constants.evaluationTime):
+	def __init__(self,playBlind=False,playPaused=False,evalTime=constants.evaluationTime,xyz=(0.8317,-0.9817,0.8),
+  hpr= (121.0,-27.500,0.0)):
 
 		self.numJoints = 0
 
@@ -31,6 +32,11 @@ class PYROSIM:
 		self.simulator = Popen(commandsToSend, stdout=PIPE, stdin=PIPE, stderr=PIPE)
 
 		# self.simulator = Popen(commandsToSend, stdout=PIPE, stdin=PIPE)
+		#Send camera position and orientation to ode -- ccappelle
+		for cam_pos in xyz:
+			self.Send(str(cam_pos)+'\n')
+		for cam_orientation in hpr:
+			self.Send(str(cam_orientation)+'\n')
 
 		self.Send('EvaluationTime '+str(evalTime)+'\n')
 

--- a/pyrosim.py
+++ b/pyrosim.py
@@ -1,7 +1,7 @@
 import math
 import sys
 import numpy as np
-
+import os
 import constants
 
 from subprocess import Popen, PIPE
@@ -11,13 +11,17 @@ class PYROSIM:
 	def __init__(self,playBlind=False,playPaused=False,evalTime=constants.evaluationTime,xyz=(0.8317,-0.9817,0.8),
   hpr= (121.0,-27.500,0.0)):
 
+		#gets directory of pyrosim
+		#useful because we can now call pyrosim from other directories
+		pyrosim_path_name=os.path.dirname(os.path.abspath(__file__)) 
+
 		self.numJoints = 0
 
 		self.numSensors = 0
 
 		self.evaluationTime = evalTime
 
-		commandsToSend = ['./simulator']
+		commandsToSend = [path_name+'/simulator']
 
 		if ( playBlind == True ):
 
@@ -30,6 +34,9 @@ class PYROSIM:
 			commandsToSend.append('-pause')
 
 		self.simulator = Popen(commandsToSend, stdout=PIPE, stdin=PIPE, stderr=PIPE)
+
+		#Sends texture path to ODE. Assumes textures are in folder called textures in pyrosim directory
+		self.Send(path_name+'/textures' + '\n')
 
 		# self.simulator = Popen(commandsToSend, stdout=PIPE, stdin=PIPE)
 		#Send camera position and orientation to ode -- ccappelle
@@ -294,7 +301,6 @@ class PYROSIM:
 	def Wait_To_Finish(self):
 
 		dataFromSimulator = self.simulator.communicate()
-
 		self.Collect_Sensor_Data(dataFromSimulator)
 
 # --------------------- Private methods -----------------------------

--- a/simulator.cpp
+++ b/simulator.cpp
@@ -9,7 +9,6 @@
 #endif
 
 #include <drawstuff/drawstuff.h>
-#include "texturepath.h"
 #ifdef dDOUBLE
 #define dsDrawLine dsDrawLineD
 #define dsDrawBox dsDrawBoxD
@@ -33,6 +32,7 @@ static dGeomID ground;
 
 static float xyz[3] = {0.8317f,-0.9817f,0.8000f};
 static float hpr[3] = {121.0000f,-27.5000f,0.0000f}; //Camera coordinates
+static char texturePathStr[100];
 
 void Draw_Distance_Sensor(dGeomID myGeom, dGeomID hisGeom);
 
@@ -190,7 +190,8 @@ void Initialize_ODE(void) {
   	fn.step = &simLoop;
   	fn.command = &command;
   	fn.stop = 0;
-  	fn.path_to_textures = DRAWSTUFF_TEXTURE_PATH;
+  	//fn.path_to_textures = DRAWSTUFF_TEXTURE_PATH; //uses user defined texture path == can call pyrosim from different directory
+    fn.path_to_textures = texturePathStr;
 
  	dInitODE2(0);
   	world = dWorldCreate();
@@ -210,6 +211,9 @@ void Initialize_Environment(void) {
 }
 
 void Read_Camera_From_Python(void){
+  //Set texture path for objects
+  std::cin >> texturePathStr;
+
     // Sets initial camera from python pipe -- ccappelle
     for (int i=0;i<3;i++){
     std::cin >> (xyz[i]);
@@ -247,6 +251,8 @@ int main (int argc, char **argv)
 	if ( (argc > 1) && (strcmp(argv[1],"-blind")==0) )
 
 		runBlind = true;
+        
+
         Read_Camera_From_Python(); //--ccappelle
 
         Initialize_ODE();

--- a/simulator.cpp
+++ b/simulator.cpp
@@ -31,6 +31,9 @@ ENVIRONMENT *environment;
 int numberOfBodies = 0;
 static dGeomID ground;
 
+static float xyz[3] = {0.8317f,-0.9817f,0.8000f};
+static float hpr[3] = {121.0000f,-27.5000f,0.0000f}; //Camera coordinates
+
 void Draw_Distance_Sensor(dGeomID myGeom, dGeomID hisGeom);
 
 void Read_From_Python(void);
@@ -125,8 +128,9 @@ static void start()
 {
   dAllocateODEDataForThread(dAllocateMaskAll);
 
-  static float xyz[3] = {0.8317f,-0.9817f,0.8000f};
-  static float hpr[3] = {121.0000f,-27.5000f,0.0000f};
+  // replaced by user input --ccappelle
+  //static float xyz[3] = {0.8317f,-0.9817f,0.8000f};
+  //static float hpr[3] = {121.0000f,-27.5000f,0.0000f};
   dsSetViewpoint (xyz,hpr);
 }
 
@@ -205,6 +209,17 @@ void Initialize_Environment(void) {
         environment = new ENVIRONMENT();
 }
 
+void Read_Camera_From_Python(void){
+    // Sets initial camera from python pipe -- ccappelle
+    for (int i=0;i<3;i++){
+    std::cin >> (xyz[i]);
+  }
+  for (int j=0;j<3;j++){
+    std::cin >> (hpr[j]);
+  }
+
+}
+
 void Read_From_Python(void) {
 
 	environment->Read_From_Python(world,space,&evaluationTime);
@@ -232,6 +247,7 @@ int main (int argc, char **argv)
 	if ( (argc > 1) && (strcmp(argv[1],"-blind")==0) )
 
 		runBlind = true;
+        Read_Camera_From_Python(); //--ccappelle
 
         Initialize_ODE();
 

--- a/texturepath.h
+++ b/texturepath.h
@@ -23,6 +23,7 @@
 // Sourceforge tests require the textures in the drawstuff folder
 
 #ifndef DRAWSTUFF_TEXTURE_PATH
-#define DRAWSTUFF_TEXTURE_PATH "../../drawstuff/textures"
+#define DRAWSTUFF_TEXTURE_PATH "./textures"
+//#define DRAWSTUFF_TEXTURE_PATH "../../drawstuff/textures"
 #endif
 


### PR DESCRIPTION
Josh,

I've been meaning to do this for a while. I've added initial camera position and orientation parameters to pyrosim so students can set up the camera in python code instead of dragging with their mouse while the simulation is running. Camera uses the standard xyz, hpr method. Without user input it will default to the camera view used before so nothing will break. I also created a demo_18 which is a copy of 17 but with different camera coordinates

Collin